### PR TITLE
Fix bool settings always casting to true

### DIFF
--- a/src/Traits/CastsToType.php
+++ b/src/Traits/CastsToType.php
@@ -220,7 +220,7 @@ trait CastsToType
                 return (string) $value;
             case 'bool':
             case 'boolean':
-                return (bool) $value;
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':


### PR DESCRIPTION
This fixes #6 by changing the castToType function to use the filter_var function rather than an explicit cast to bool which was causing string values to always be casted to true.